### PR TITLE
Update save button selector

### DIFF
--- a/src/maps/importPlaces.js
+++ b/src/maps/importPlaces.js
@@ -119,7 +119,7 @@ const importPlaces = async (argv) => {
       async (name, listIndex, listName) => {
         await window.delay(150);
         let saveButton = document.querySelector(
-          "button[jsaction='pane.placeActions.save;keydown:pane.placeActions.save']"
+          "button[jsaction*='pane.placeActions.save']"
         );
         let message = "";
 


### PR DESCRIPTION
Since the selector for the button has updated to have more "jsaction" values assigned, the save button no longer works.

This is how the attribute was changed on Google Maps:
```diff
- jsaction="pane.placeActions.save;keydown:pane.placeActions.save"
+ jsaction="pane.placeActions.save;keydown:pane.placeActions.save;mouseover:pane.placeActions.save;mouseout:pane.placeActions.save"
```

Instead of patching it up by updating the selector the match it verbatim, I've made the selector simply need to partially match the relevant action: `pane.placeActions.save`. This doesn't appear anywhere else on the page and would be resilient to future changes of the sort.